### PR TITLE
Fix publish command in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: pnpm run build & pnpm publish --access public
+          publish: pnpm run build && pnpm publish --access public
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fix publish command in publish.yml to use '&&' instead of '&' to ensure build completes before publishing